### PR TITLE
Better Fine Control of Gripper During Intake Extension

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Config.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Config.java
@@ -58,6 +58,7 @@ public class Config {
     // Multiplier starts at 0.1 and increments by acceleration each loop up to 1
     // Only used in PID Drive (deprecated)
     public static final double acceleration = 0.04;
+    public static final double EXTENSION_TURN_POWER_DEMULTIPLIER = 0.5;
 
     // Color sensor
     public static final int[] colorRed = {190, 110, 65}; // Red sample color (rgb)

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Teleop/Drivers/TeleopDriver1.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Teleop/Drivers/TeleopDriver1.java
@@ -5,6 +5,7 @@ import com.qualcomm.robotcore.util.ElapsedTime;
 
 import org.firstinspires.ftc.teamcode.Bot;
 import org.firstinspires.ftc.teamcode.Helpers.Toggle;
+import org.firstinspires.ftc.teamcode.Config;
 
 public class TeleopDriver1 {
     private final Gamepad gamepad;
@@ -90,7 +91,7 @@ public class TeleopDriver1 {
     private void driveRobot() {
         double px = Math.pow(gamepad.left_stick_x, 3);
         double py = -Math.pow(gamepad.left_stick_y, 3);
-        double turn = gamepad.right_stick_x;
+        double turn = gamepad.right_stick_x * (Bot.intake.isExtended() ? Config.EXTENSION_TURN_POWER_DEMULTIPLIER : 1);
         Bot.mecanumBase.move(px, py, turn, speed);
     }
 


### PR DESCRIPTION
Added a Demultiplier to help with the high-speed whipping of gripper end-effector.  Change multiplier as needed with testing and driver preferences.

_Note: Followed conventional CONSTANT_DEFINITON syntax._ 