### PR TITLE
Use this code to confirm which of the 3 booleans are failing when run…

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autos/SampleAutoWait.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autos/SampleAutoWait.java
@@ -211,7 +211,16 @@ public class SampleAutoWait extends LinearOpMode {
         handleIntake();
         Bot.slideArm.moveDown(0.8);
         Bot.purePursuit.update();
-        if (Bot.purePursuit.reachedTarget(1) && intakeState == IntakeState.NONE && Bot.slideArm.isDown()) {
+
+        boolean didReachTarget = Bot.purePursuit.reachedTarget(1);
+        boolean currentIntakeState = intakeState == IntakeState.NONE;
+        boolean isSlideArmDown = Bot.slideArm.isDown();
+
+        telemetry.addData("didReachTarget", didReachTarget);
+        telemetry.addData("currentIntakeState", currentIntakeState);
+        telemetry.addData("isSlideArmDown", isSlideArmDown);
+
+        if (didReachTarget && currentIntakeState && isSlideArmDown) {
             Bot.purePursuit.stop();
             Bot.intake.misumiWristDown();
             servoPosTimer.reset();


### PR DESCRIPTION
…ning the Sample Auto as it did fail on 2/18/25 at around 8pm.

From looking at the video, my guess is that the intake slide is bouncing and therefore is failing the "didReachTarget" boolean, but it could be failing any of those booleans. (Notice the pattern of pulling the booleans out of the if statement for easier troubleshooting and testing)

If that is confirmed then maybe the tolerance of "1" could be adjusted for the xTolerance, or the Config.turnTolerance may need to be avoided and instead use "reachedTargetXY(double xTolerance, double yTolerance)" to pass in a higher value for y.