### PR TITLE
Educational/specimen auto slightly faster

### DIFF
--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Config.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/Config.java
@@ -201,6 +201,19 @@ public class Config {
     public static final double[] pickSample3 = {25, 65};
     public static final double[] submersablePickup = {120, 160};
 
+    // Speed adjustments on Specimen Auto
+    /*
+     If these adjustments can gain 0.5 of a second, then the additional 3 points for park may be attainable
+     These numbers may be too aggressive and cause issues, so they will need to be tested
+     Set these back to 0 to get current speeds
+    */
+    public static final double specimenAutoHandleSampleSpeedAdjustment = 0.10; // could be up to 0.15
+    public static final double specimenAutoPushSpeedAdjustment = 0.25; // could be 0.35
+    public static final double specimenAutoPrepHangSpecimentSpeedAdjustment = 0.25; // could be up to 0.5
+    public static final double specimenAutoDelaySpcimenArmAdjustment = -100; // could be up to -350, but there needs to be some delay so the arm does't hit the wall after pick up
+
     // ---- Misc ----
     public static final double defaultMaxCurrent = 6000;
+
+
 }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autos/SpecimenAuto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autos/SpecimenAuto.java
@@ -82,12 +82,13 @@ public class SpecimenAuto extends LinearOpMode {
                 0.25 // Offset Y
         );
         // Schedule specimen arm movement
+        long delay = (long)(350 - Config.specimenAutoDelaySpcimenArmAdjustment);
         armSchedule.schedule(new TimerTask() {
             @Override
             public void run() {
                 Bot.specimenArm.movePrepHang(1);
             }
-        }, 250); // UPDATED: - was 350
+        }, delay);
         state = State.SPECIMEN_HANG;
     }
 
@@ -107,10 +108,10 @@ public class SpecimenAuto extends LinearOpMode {
 
         if (specimensLeft == totalSpecimens) {
             // Go slower on first hang
-            Bot.purePursuit.update(0.65); // UPDATED: - was 0.4
+            Bot.purePursuit.update(0.4 + Config.specimenAutoPushSpeedAdjustment);
         } else {
             // Go faster on subsequent hangs
-            Bot.purePursuit.update(0.9); // UPDATED: - was 0.65
+            Bot.purePursuit.update(0.65 + Config.specimenAutoPushSpeedAdjustment);
         }
 
         if (Bot.purePursuit.reachedTarget(2.5)) {
@@ -144,7 +145,7 @@ public class SpecimenAuto extends LinearOpMode {
     }
 
     private void handlePushSampleOne() {
-        Bot.purePursuit.update(0.95); // UPDATED: - was 0.85
+        Bot.purePursuit.update(0.85 + Config.specimenAutoHandleSampleSpeedAdjustment);
         if (Bot.purePursuit.reachedTarget(5)) {
             AutoPaths.pushSample2(
                     Bot.pinpoint.getX(), // Current X
@@ -155,7 +156,7 @@ public class SpecimenAuto extends LinearOpMode {
     }
 
     private void handlePushSampleTwo() {
-        Bot.purePursuit.update(0.9); // UPDATED: - was 0.8
+        Bot.purePursuit.update(0.8 + Config.specimenAutoHandleSampleSpeedAdjustment);
         if (Bot.purePursuit.reachedTarget(5)) {
             AutoPaths.pushSample3(
                     Bot.pinpoint.getX(), // Current X
@@ -166,7 +167,7 @@ public class SpecimenAuto extends LinearOpMode {
     }
 
     private void handlePushSampleThree() {
-        Bot.purePursuit.update(0.85); // UPDATED: - was 0.75
+        Bot.purePursuit.update(0.75 + Config.specimenAutoHandleSampleSpeedAdjustment);
         if (Bot.purePursuit.reachedTarget(5)) {
             AutoPaths.collectSpecimen(
                     Bot.pinpoint.getX(), // Current X
@@ -196,7 +197,7 @@ public class SpecimenAuto extends LinearOpMode {
                     offsetX, // Hang offsetX X
                     0 // Offset Y
             );
-            Bot.specimenArm.movePrepHang(0.75); // UPDATED: - was 0.5
+            Bot.specimenArm.movePrepHang(0.5 + Config.specimenAutoPrepHangSpecimentSpeedAdjustment);
             specimensLeft--;
             state = State.SPECIMEN_HANG;
         }

--- a/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autos/SpecimenAuto.java
+++ b/TeamCode/src/main/java/org/firstinspires/ftc/teamcode/OpModes/Autos/SpecimenAuto.java
@@ -87,7 +87,7 @@ public class SpecimenAuto extends LinearOpMode {
             public void run() {
                 Bot.specimenArm.movePrepHang(1);
             }
-        }, 350);
+        }, 250); // UPDATED: - was 350
         state = State.SPECIMEN_HANG;
     }
 
@@ -107,10 +107,10 @@ public class SpecimenAuto extends LinearOpMode {
 
         if (specimensLeft == totalSpecimens) {
             // Go slower on first hang
-            Bot.purePursuit.update(0.4);
+            Bot.purePursuit.update(0.65); // UPDATED: - was 0.4
         } else {
             // Go faster on subsequent hangs
-            Bot.purePursuit.update(0.65);
+            Bot.purePursuit.update(0.9); // UPDATED: - was 0.65
         }
 
         if (Bot.purePursuit.reachedTarget(2.5)) {
@@ -144,7 +144,7 @@ public class SpecimenAuto extends LinearOpMode {
     }
 
     private void handlePushSampleOne() {
-        Bot.purePursuit.update(0.85);
+        Bot.purePursuit.update(0.95); // UPDATED: - was 0.85
         if (Bot.purePursuit.reachedTarget(5)) {
             AutoPaths.pushSample2(
                     Bot.pinpoint.getX(), // Current X
@@ -155,7 +155,7 @@ public class SpecimenAuto extends LinearOpMode {
     }
 
     private void handlePushSampleTwo() {
-        Bot.purePursuit.update(0.8);
+        Bot.purePursuit.update(0.9); // UPDATED: - was 0.8
         if (Bot.purePursuit.reachedTarget(5)) {
             AutoPaths.pushSample3(
                     Bot.pinpoint.getX(), // Current X
@@ -166,7 +166,7 @@ public class SpecimenAuto extends LinearOpMode {
     }
 
     private void handlePushSampleThree() {
-        Bot.purePursuit.update(0.75);
+        Bot.purePursuit.update(0.85); // UPDATED: - was 0.75
         if (Bot.purePursuit.reachedTarget(5)) {
             AutoPaths.collectSpecimen(
                     Bot.pinpoint.getX(), // Current X
@@ -196,7 +196,7 @@ public class SpecimenAuto extends LinearOpMode {
                     offsetX, // Hang offsetX X
                     0 // Offset Y
             );
-            Bot.specimenArm.movePrepHang(0.5);
+            Bot.specimenArm.movePrepHang(0.75); // UPDATED: - was 0.5
             specimensLeft--;
             state = State.SPECIMEN_HANG;
         }


### PR DESCRIPTION
Speed adjustments on Specimen Auto
     If these adjustments can gain 0.5 of a second, then the additional 3 points for park may be attainable
     These numbers may be too aggressive and cause issues, so they will need to be tested
     Set these back to 0 to get current speeds
